### PR TITLE
[CTMD#449] lower-case heal user list items before string comparison

### DIFF
--- a/api/utils/helpers.js
+++ b/api/utils/helpers.js
@@ -25,6 +25,7 @@ exports.getHealUsers = (filePath) => {
   try {
     const data = fs.readFileSync(filePath, 'utf8')
     return data.split('\n')
+      .map(address => address.toLowerCase())
   } catch (err) {
     console.error(err)
   }


### PR DESCRIPTION
this will fix the issue of failing HEAL access for access list items containing upper-case characters.