### PR TITLE
[CTMD/#449] adjust isPLAdmin variable assignment

### DIFF
--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -50,7 +50,7 @@ export const AuthProvider = ({ children }) => {
     const response = await axios.get(api.authStatus, { withCredentials: true })
     const data = response.data
     if (response.status == 200) {
-      const isPLAdmin = typeof data.isHealUser === 'undefined' ? true : data.isHealUser
+      const isPLAdmin = typeof data.isHealUser === 'boolean' ? data.isHealUser : false
       setUser(data)
       setLocalStorageUser(data)
       setAuthenticated(data.authenticated)


### PR DESCRIPTION
this addresses the client's email-based HEAL write access check, CTMD/#449.

i've switched the logic in the definition is `isPLAdmin` to use the boolean value if it is indeed a boolean. otherwise, set the value to false.