### PR TITLE
Bugfix/enrollment percentages

### DIFF
--- a/frontend/src/utils/DateFormat.js
+++ b/frontend/src/utils/DateFormat.js
@@ -13,6 +13,6 @@ const monthNames = [
   'December',
 ]
 
-export const formatDate = (date, options = { year: 'numeric', month: 'long', day: '2-digit' }, locales = 'en-US') => {
+export const formatDate = (date, options = { year: 'numeric', month: 'long', day: '2-digit', timeZone: 'UTC' }, locales = 'en-US') => {
   return date.toLocaleDateString(locales, options)
 }

--- a/frontend/src/views/Studies/Milestones.js
+++ b/frontend/src/views/Studies/Milestones.js
@@ -133,25 +133,45 @@ export const Milestones = ({ sites, sitesCount, enrollmentGoal }) => {
                 </ListItem>
                 <ListItem>
                   <ListItemText
-                    primary={ <span>25% of Sites Activated ({ Math.ceil(sitesCount * 0.25) } / { sitesCount })</span> }
+                    primary={
+                      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                        <span>25% of Sites Activated</span>
+                        <span>( { Math.ceil(sitesCount * 0.25) } / { sitesCount } )</span>
+                      </div>
+                    }
                     secondary={ siteActivationPercentages[0] }
                   />
                 </ListItem>
                 <ListItem>
                   <ListItemText
-                    primary={ <span>50% of Sites Activated ({ Math.ceil(sitesCount * 0.5) } / { sitesCount })</span> }
+                    primary={
+                      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                        <span>50% of Sites Activated</span>
+                        <span>( { Math.ceil(sitesCount * 0.5) } / { sitesCount } )</span>
+                      </div>
+                    }
                     secondary={ siteActivationPercentages[1] }
                   />
                 </ListItem>
                 <ListItem>
                   <ListItemText
-                    primary={ <span>75% of Sites Activated ({ Math.ceil(sitesCount * 0.75) } / { sitesCount })</span> }
+                    primary={
+                      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                        <span>75% of Sites Activated</span>
+                        <span>( { Math.ceil(sitesCount * 0.75) } / { sitesCount } )</span>
+                      </div>
+                    }
                     secondary={ siteActivationPercentages[2] }
                   />
                 </ListItem>
                 <ListItem>
                   <ListItemText
-                    primary={ <span>100% of Sites Activated ({ sitesCount } / { sitesCount })</span> }
+                    primary={
+                      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                        <span>100% of Sites Activated</span>
+                        <span>( { sitesCount } / { sitesCount } )</span>
+                      </div>
+                    }
                     secondary={ siteActivationPercentages[3] }
                   />
                 </ListItem>

--- a/frontend/src/views/Studies/Milestones.js
+++ b/frontend/src/views/Studies/Milestones.js
@@ -47,7 +47,7 @@ export const Milestones = ({ sites, sitesCount, enrollmentGoal }) => {
     dates.forEach(date => {
       if (!!date) {
         count += 1
-        if (count / sites.length >= 0.25 + 0.25 * thresholdDates.length) {
+        if (count / sitesCount >= 0.25 + 0.25 * thresholdDates.length) {
           thresholdDates.push(date)
         }
       }

--- a/frontend/src/views/Studies/Milestones.js
+++ b/frontend/src/views/Studies/Milestones.js
@@ -132,16 +132,28 @@ export const Milestones = ({ sites, sitesCount, enrollmentGoal }) => {
                   <ListItemText primary="First Subject Enrolled" secondary={firstSubjectEnrolled}></ListItemText>
                 </ListItem>
                 <ListItem>
-                  <ListItemText primary="25% of Sites Activated" secondary={siteActivationPercentages[0]}></ListItemText>
+                  <ListItemText
+                    primary={ <span>25% of Sites Activated ({ Math.ceil(sitesCount * 0.25) } / { sitesCount })</span> }
+                    secondary={ siteActivationPercentages[0] }
+                  />
                 </ListItem>
                 <ListItem>
-                  <ListItemText primary="50% of Sites Activated" secondary={siteActivationPercentages[1]}></ListItemText>
+                  <ListItemText
+                    primary={ <span>50% of Sites Activated ({ Math.ceil(sitesCount * 0.5) } / { sitesCount })</span> }
+                    secondary={ siteActivationPercentages[1] }
+                  />
                 </ListItem>
                 <ListItem>
-                  <ListItemText primary="75% of Sites Activated" secondary={siteActivationPercentages[2]}></ListItemText>
+                  <ListItemText
+                    primary={ <span>75% of Sites Activated ({ Math.ceil(sitesCount * 0.75) } / { sitesCount })</span> }
+                    secondary={ siteActivationPercentages[2] }
+                  />
                 </ListItem>
                 <ListItem>
-                  <ListItemText primary="100% of Sites Activated" secondary={siteActivationPercentages[3]}></ListItemText>
+                  <ListItemText
+                    primary={ <span>100% of Sites Activated ({ sitesCount } / { sitesCount })</span> }
+                    secondary={ siteActivationPercentages[3] }
+                  />
                 </ListItem>
               </List>
             </CardContent>


### PR DESCRIPTION
this PR fixes two things
- milestone enrollment percentage calculations were using the length of the sites array for the denominator, when the denominator should be the value of "number of initial participating sites" from the study profile
- the one-day-off bug in the milestone calculations