### PR TITLE
fix pipeline version number

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   pipeline:
     container_name: ctmd-pipeline-dev
-    image: txscience/ctmd-pipeline-reload:2.5
+    image: txscience/ctmd-pipeline-reload:v2.5
     restart: always
     environment:
       POSTGRES_DATABASE_NAME: $POSTGRES_DB


### PR DESCRIPTION
this PR changes `txscience/ctmd-pipeline-reload:2.5` to `txscience/ctmd-pipeline-reload:v2.5` in the development docker-compose file. this is already correct in the production docker-compose file.