### PR TITLE
remove synthetic data volume mapping from docker-compose.prod.yml file

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,7 +55,6 @@ services:
       - $FILTER_PATH:/filter
       - $BLOCK_PATH:/block
       - $MAPPING_LOCAL_PATH:/mapping.json
-      - ./syntheticDataset.json:$DATA_INPUT_FILE_PATH
     depends_on:
       - db
       - redis

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,6 +55,9 @@ services:
       - $FILTER_PATH:/filter
       - $BLOCK_PATH:/block
       - $MAPPING_LOCAL_PATH:/mapping.json
+      # Note the line below is for using syntheticDataset.json for demo purposes rather than
+      # using real redcap data downloaded and synced from redcap site.
+      # - ./syntheticDataset.json:$DATA_INPUT_FILE_PATH
     depends_on:
       - db
       - redis


### PR DESCRIPTION
@mbwatson @krobasky This PR fixes the redcap download error on stage and dev. On prod, this line was manually commented out so prod does not run into redcap download error as stage and dev when doing data sync. 