### PR TITLE
Use custom render to access short description in protocol

### DIFF
--- a/frontend/src/components/Tables/SitesTable.js
+++ b/frontend/src/components/Tables/SitesTable.js
@@ -70,7 +70,7 @@ export const SitesTable = props => {
             components={{ }}
             columns={
                 [
-                    { title: 'Protocol (Short Description)', field: 'protocol', hidden: true, },
+                    { title: 'Protocol (Short Description)', render: d => d.protocol.shortDescription, hidden: true, },
                     { title: 'Site ID', field: 'siteId', hidden: false, },
                     { title: 'CTSA ID', field: 'ctsaId', hidden: true, },
                     { title: 'Site Name', field: 'siteName', hidden: false, },


### PR DESCRIPTION
Sites table was using the protocol field for Protocol (Short Description), but protocol is an object. Now using custom render to access the shortDescription field in the protocol object.