### PR TITLE
API build issues

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -14,14 +14,6 @@ ENV PATH /usr/local/node_modules/.bin:$PATH
 
 ENV NODE_ENV development
 ENV TZ America/New_York
-ENV API_PORT 3030
-ENV GRAPHICS_API_PORT 4040
-ENV REACT_APP_API_ROOT http://localhost/api/
-ENV REACT_APP_DATA_API_ROOT http://localhost/data/
-ENV REACT_APP_AUTH_API_KEY supersecretlongstring
-ENV API_SESSION_SECRET something-secret
-ENV AUTH_API_KEY SECRET
-
 
 # RUN npm install nodemon
 COPY ./package*.json ./

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,8 @@
-FROM node:13.14.0
+FROM node:18-bullseye
 
-RUN apt-get update && apt-get install -y nano tree tzdata
+RUN apt update
+
+RUN apt install tzdata
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -11,7 +13,15 @@ ENV PATH /usr/src/app/node_modules/.bin:$PATH
 ENV PATH /usr/local/node_modules/.bin:$PATH
 
 ENV NODE_ENV development
-ENV TZ=America/New_York
+ENV TZ America/New_York
+ENV API_PORT 3030
+ENV GRAPHICS_API_PORT 4040
+ENV REACT_APP_API_ROOT http://localhost/api/
+ENV REACT_APP_DATA_API_ROOT http://localhost/data/
+ENV REACT_APP_AUTH_API_KEY supersecretlongstring
+ENV API_SESSION_SECRET something-secret
+ENV AUTH_API_KEY SECRET
+
 
 # RUN npm install nodemon
 COPY ./package*.json ./


### PR DESCRIPTION
this bumps the Node base image from `node:13.14.0` to `node:18-bullseye` and removes `nano` and `tree` utilities, retaining installation of `tzdata`.