### PR TITLE
Pipeline2: Week 3 orchestration and infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test-pipeline2:
 	containers.renci.org/ctmd/$(PIPELINE2_BASE_IMAGE):$(PIPELINE2_TAG) \
 	python -m pytest tests/ -v
 
-build-all: build-api build-ui build-pipeline
+build-all: build-api build-ui build-pipeline build-pipeline2
 
 push-ui:
 	docker push containers.renci.org/ctmd/$(UI_BASE_IMAGE):$(UI_TAG)
@@ -122,7 +122,7 @@ push-api-dockerhub:
 push-pipeline-dockerhub:
 	dockerhub push rencibuild/$(PIPELINE_BASE_IMAGE):$(PIPELINE_TAG)
 
-push-all: push-api push-ui push-pipeline
+push-all: push-api push-ui push-pipeline push-pipeline2
 # ==============================================================================
 ## KiND Kubernetes 
 #
@@ -156,9 +156,14 @@ kind-load-ui:
 kind-load-pipeline:
 		kind load docker-image \
 	  containers.renci.org/ctmd/$(PIPELINE_BASE_IMAGE):$(PIPELINE_TAG) \
-		--name $(KIND_CLUSTER)	
+		--name $(KIND_CLUSTER)
 
-kind-load: kind-load-ui kind-load-api kind-load-pipeline
+kind-load-pipeline2:
+	kind load docker-image \
+	  containers.renci.org/ctmd/$(PIPELINE2_BASE_IMAGE):$(PIPELINE2_TAG) \
+		--name $(KIND_CLUSTER)
+
+kind-load: kind-load-ui kind-load-api kind-load-pipeline kind-load-pipeline2
 
 # =======================================================
 ## Helm

--- a/helm-charts/ctmd-dashboard/values.yaml
+++ b/helm-charts/ctmd-dashboard/values.yaml
@@ -155,6 +155,51 @@ redis:
       cpu: 200m
       memory: 300Mi
 
+pipeline2:
+  create: false  # Set to true to deploy pipeline2 alongside pipeline (cutover mode)
+  name: ctmd-pipeline2
+  tag: "v0.1.0"
+  service:
+    port: 5000
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 200m
+      memory: 300Mi
+  recurringBackup:
+    backupPath: "/backups"
+    storageClass:  # Leave blank for default "standard"
+    size: "1Gi"
+    persistence:
+      create: true
+      existingClaim: "db-backups-pvc"
+  env:
+    # REDCap connection
+    REDCAP_APPLICATION_TOKEN: ""
+    REDCAP_URL_BASE: "https://redcap.vumc.org/api/"
+    # Database — constructed from db-dsn secret in the Helm template
+    DATABASE_URL: ""
+    MAPPING_PATH: "/data/mapping.json"
+    BACKUP_DIR: "/backups"
+    # Startup behaviour
+    CREATE_TABLES: "1"           # apply SQL migrations on startup
+    SYNC_INTERVAL_HOURS: "24"    # scheduled REDCap sync interval (0 = disabled)
+    # Redis task queue
+    REDIS_QUEUE_HOST: "ctmd-redis"
+    REDIS_QUEUE_PORT: "6379"
+    REDIS_QUEUE_DB: "0"
+    # Redis distributed lock (Sherlock) — prevents concurrent syncs
+    REDIS_LOCK_HOST: "ctmd-redis"
+    REDIS_LOCK_PORT: "6379"
+    REDIS_LOCK_DB: "1"
+    REDIS_LOCK_EXPIRE: "7200"
+    REDIS_LOCK_TIMEOUT: "7200"
+    TASK_TIME: "7200"
+    LOCAL_ENV: "true"            # set to false for production (disables CORS)
+    USE_SPARK_ETL: "0"           # rollback flag; 0 = use Python pipeline
+
 pipeline:
   create: true
   name: ctmd-pipeline

--- a/services/pipeline2/Dockerfile
+++ b/services/pipeline2/Dockerfile
@@ -17,3 +17,5 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.source="https://github.com/renci/ctmd-dashboard" \
       org.opencontainers.image.revision="${BUILD_REF}" \
       org.opencontainers.image.vendor="RENCI - Renaissance Computing Institute"
+
+CMD ["python", "main.py"]

--- a/services/pipeline2/main.py
+++ b/services/pipeline2/main.py
@@ -1,0 +1,196 @@
+"""Pipeline entry point.
+
+Startup sequence:
+1. Read env vars
+2. Wait for Redis and PostgreSQL to become reachable
+3. Apply pending SQL migrations (when CREATE_TABLES=1)
+4. Start Flask API server as a subprocess
+5. Start RQ worker as a subprocess
+6. Run the sync scheduler loop (schedule library)
+
+Sync concurrency:
+  _run_sync (server.py) acquires a Sherlock Redis lock so only one sync
+  runs at a time, whether triggered by the scheduler here or by POST /sync.
+"""
+
+import logging
+import os
+import time
+from multiprocessing import Process
+
+import redis
+import schedule
+from rq import Queue
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Dependency wait helpers
+# ---------------------------------------------------------------------------
+
+def _wait_for_redis(conn, retries: int = 30, delay: int = 2) -> None:
+    for attempt in range(retries):
+        try:
+            conn.ping()
+            return
+        except Exception:
+            log.info("Waiting for Redis (attempt %d/%d)...", attempt + 1, retries)
+            time.sleep(delay)
+    raise RuntimeError("Redis not available after %d retries" % retries)
+
+
+def _wait_for_postgres(database_url: str, retries: int = 30, delay: int = 2) -> None:
+    import psycopg2
+    for attempt in range(retries):
+        try:
+            c = psycopg2.connect(database_url)
+            c.close()
+            return
+        except Exception:
+            log.info("Waiting for PostgreSQL (attempt %d/%d)...", attempt + 1, retries)
+            time.sleep(delay)
+    raise RuntimeError("PostgreSQL not available after %d retries" % retries)
+
+
+# ---------------------------------------------------------------------------
+# Migrations
+# ---------------------------------------------------------------------------
+
+def _apply_migrations(database_url: str) -> None:
+    import psycopg2
+    from loader.loader import apply_migrations
+    migrations_dir = os.path.join(os.path.dirname(__file__), "migrations")
+    conn = psycopg2.connect(database_url)
+    try:
+        applied = apply_migrations(conn, migrations_dir)
+        if applied:
+            log.info("Applied migrations: %s", applied)
+        else:
+            log.info("No new migrations to apply")
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Subprocess targets
+# ---------------------------------------------------------------------------
+
+def _run_flask() -> None:
+    """Flask API server (runs in its own process)."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    from server import create_app
+    app = create_app()
+    app.run(host="0.0.0.0", port=5000)
+
+
+def _run_worker() -> None:
+    """RQ worker (runs in its own process)."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    import redis as redis_lib
+    from rq import Worker, Queue as RQQueue
+    r = redis_lib.StrictRedis(
+        host=os.environ.get("REDIS_QUEUE_HOST", "localhost"),
+        port=int(os.environ.get("REDIS_QUEUE_PORT", 6379)),
+        db=int(os.environ.get("REDIS_QUEUE_DB", 0)),
+    )
+    q = RQQueue(connection=r)
+    worker = Worker([q], connection=r)
+    worker.work()
+
+
+# ---------------------------------------------------------------------------
+# Scheduler
+# ---------------------------------------------------------------------------
+
+def _enqueue_sync(queue: Queue) -> None:
+    """Enqueue a REDCap sync job onto the RQ queue."""
+    from server import _run_sync
+    database_url = os.environ.get("DATABASE_URL", "")
+    mapping_path = os.environ.get("MAPPING_PATH", "/data/mapping.json")
+    task_time = int(os.environ.get("TASK_TIME", 3600))
+    log.info("Enqueueing scheduled REDCap sync")
+    queue.enqueue(_run_sync, database_url, mapping_path, job_timeout=task_time)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    database_url = os.environ.get("DATABASE_URL", "")
+    create_tables = os.environ.get("CREATE_TABLES", "0") == "1"
+    sync_interval_hours = int(os.environ.get("SYNC_INTERVAL_HOURS", 24))
+
+    # 1. Wait for Redis
+    r = redis.StrictRedis(
+        host=os.environ.get("REDIS_QUEUE_HOST", "localhost"),
+        port=int(os.environ.get("REDIS_QUEUE_PORT", 6379)),
+        db=int(os.environ.get("REDIS_QUEUE_DB", 0)),
+    )
+    _wait_for_redis(r)
+    log.info("Redis ready")
+
+    # 2. Wait for PostgreSQL and apply migrations
+    if database_url:
+        _wait_for_postgres(database_url)
+        log.info("PostgreSQL ready")
+        if create_tables:
+            log.info("Applying migrations...")
+            _apply_migrations(database_url)
+
+    # 3. Start Flask API subprocess
+    flask_proc = Process(target=_run_flask, name="flask-api", daemon=True)
+    flask_proc.start()
+    log.info("Flask API started (pid=%d)", flask_proc.pid)
+
+    # 4. Start RQ worker subprocess
+    worker_proc = Process(target=_run_worker, name="rq-worker", daemon=True)
+    worker_proc.start()
+    log.info("RQ worker started (pid=%d)", worker_proc.pid)
+
+    # 5. Schedule periodic sync
+    queue = Queue(connection=r)
+    if sync_interval_hours > 0:
+        schedule.every(sync_interval_hours).hours.do(_enqueue_sync, queue)
+        log.info("Sync scheduled every %d hour(s)", sync_interval_hours)
+    else:
+        log.info("Scheduled sync disabled (SYNC_INTERVAL_HOURS=0)")
+
+    # Scheduler loop — also watches for crashed subprocesses
+    try:
+        while True:
+            schedule.run_pending()
+            time.sleep(30)
+
+            if not flask_proc.is_alive():
+                log.warning("Flask process exited (code=%s), restarting", flask_proc.exitcode)
+                flask_proc = Process(target=_run_flask, name="flask-api", daemon=True)
+                flask_proc.start()
+
+            if not worker_proc.is_alive():
+                log.warning("Worker process exited (code=%s), restarting", worker_proc.exitcode)
+                worker_proc = Process(target=_run_worker, name="rq-worker", daemon=True)
+                worker_proc.start()
+
+    except KeyboardInterrupt:
+        log.info("Shutting down")
+        flask_proc.terminate()
+        worker_proc.terminate()
+        flask_proc.join(timeout=5)
+        worker_proc.join(timeout=5)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/pipeline2/server.py
+++ b/services/pipeline2/server.py
@@ -252,19 +252,38 @@ def _update_column(database_url: str, table: str, column: str, tmpfile: str) -> 
 
 
 def _run_sync(database_url: str, mapping_path: str) -> bool:
-    """Download from REDCap, transform, and bulk-load all REDCap-sourced tables."""
+    """Download from REDCap, transform, and bulk-load all REDCap-sourced tables.
+
+    Acquires a Sherlock Redis distributed lock so only one sync runs at a
+    time, whether triggered by the scheduler in main.py or by POST /sync.
+    """
+    import redis as redis_lib
+    from sherlock import RedisLock
     from redcap_importer.downloader import RedcapDownloader
     from transformer.transforms import transform_all
     from loader.loader import connect, sync_redcap_tables
 
+    lock_client = redis_lib.StrictRedis(
+        host=os.environ.get("REDIS_LOCK_HOST", os.environ.get("REDIS_QUEUE_HOST", "localhost")),
+        port=int(os.environ.get("REDIS_LOCK_PORT", os.environ.get("REDIS_QUEUE_PORT", "6379"))),
+        db=int(os.environ.get("REDIS_LOCK_DB", 1)),
+    )
+    lock = RedisLock(
+        "ctmd-sync",
+        client=lock_client,
+        expire=int(os.environ.get("REDIS_LOCK_EXPIRE", 7200)),
+        timeout=int(os.environ.get("REDIS_LOCK_TIMEOUT", 7200)),
+    )
+
     try:
-        records = RedcapDownloader(mapping_path).download_all()
-        table_data = transform_all(records)
-        conn = connect(database_url)
-        counts = sync_redcap_tables(conn, table_data)
-        conn.close()
-        logger.info("sync complete: %s", counts)
-        return True
+        with lock:
+            records = RedcapDownloader(mapping_path).download_all()
+            table_data = transform_all(records)
+            conn = connect(database_url)
+            counts = sync_redcap_tables(conn, table_data)
+            conn.close()
+            logger.info("sync complete: %s", counts)
+            return True
     except Exception as e:
         logger.exception("sync failed: %s", e)
         return False

--- a/services/pipeline2/worker.py
+++ b/services/pipeline2/worker.py
@@ -1,0 +1,28 @@
+"""
+RQ worker entry point.
+
+Can be run standalone (python worker.py) for debugging, or is launched
+as a subprocess by main.py during normal pipeline operation.
+Reads Redis configuration from the same env vars as main.py.
+"""
+
+import logging
+import os
+
+import redis
+from rq import Queue, Worker
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+
+if __name__ == "__main__":
+    r = redis.StrictRedis(
+        host=os.environ.get("REDIS_QUEUE_HOST", "localhost"),
+        port=int(os.environ.get("REDIS_QUEUE_PORT", 6379)),
+        db=int(os.environ.get("REDIS_QUEUE_DB", 0)),
+    )
+    q = Queue(connection=r)
+    worker = Worker([q], connection=r)
+    worker.work()


### PR DESCRIPTION
- main.py: entry point — waits for Redis/Postgres, applies migrations, starts Flask API and RQ worker as subprocesses, runs sync scheduler
- worker.py: standalone RQ worker (also used as subprocess target)
- server.py: add Sherlock Redis distributed lock to _run_sync to prevent concurrent syncs regardless of trigger source
- Dockerfile: add CMD ["python", "main.py"]
- values.yaml: add pipeline2 section (no Spark vars, SYNC_INTERVAL_HOURS, USE_SPARK_ETL rollback flag); create: false until cutover
- Makefile: add pipeline2 to build-all, push-all, kind-load targets

