### PR TITLE
ctmd-155: use Recreate strategy to avoid RWO PVC deploy deadlock

### DIFF
--- a/helm-charts/ctmd-dashboard/templates/pipeline.yaml
+++ b/helm-charts/ctmd-dashboard/templates/pipeline.yaml
@@ -60,6 +60,10 @@ metadata:
   name: {{ .Values.pipeline.name }}
 spec:
   replicas: 1
+  # RWO backup PVC means a RollingUpdate deadlocks on the same volume; same
+  # rationale as pipeline2. See pipeline2.yaml for details.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: {{ .Values.pipeline.name }}

--- a/helm-charts/ctmd-dashboard/templates/pipeline2.yaml
+++ b/helm-charts/ctmd-dashboard/templates/pipeline2.yaml
@@ -40,6 +40,12 @@ metadata:
   name: {{ .Values.pipeline2.name }}
 spec:
   replicas: 1
+  # RWO backup PVC means a RollingUpdate deadlocks: the new pod can't attach
+  # the volume while the old one still holds it. Recreate tears down the old
+  # pod first, releases the PVC, then brings up the new pod. Trade is ~30-60s
+  # of /data/* unavailability per upgrade.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: {{ .Values.pipeline2.name }}


### PR DESCRIPTION
## Summary

Sets `spec.strategy.type: Recreate` on the `ctmd-pipeline2` and `ctmd-pipeline` (legacy) Deployments so helm upgrades stop deadlocking on the ReadWriteOnce backup PVCs.

## Why

Both deployments mount a RWO PVC (`db-backups-pipeline2-pvc` and `db-backups-pvc` respectively). With the default `RollingUpdate` strategy, k8s tries to start the new pod alongside the old one — but the new pod can't attach the volume while the old pod still holds it. Every helm upgrade gets stuck in `Init:0/1` until someone manually scale-cycles the deployment (0 → 1).

We hit this on both stage and prod during the v3.1.19 rollout (ctmd-141). With `Recreate`, the old pod terminates first, the PVC releases, then the new pod starts cleanly.

## Tradeoff

~30–60s of `/data/*` unavailability per upgrade (the time the new pipeline2 pod takes to boot). `/api/*` keeps serving because `ctmd-api` talks directly to `ctmd-db2`, not pipeline2. No data risk — PVCs persist across pod restarts; this just changes the ordering.

## Not in scope (follow-up worth considering)

- The two postgres Deployments (`ctmd-db`, `ctmd-db2`) also mount RWO PVCs and have the same problem in theory. They rarely get rolled, so we've never tripped it. Same one-line fix would future-proof them.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` shows `strategy.type: Recreate` rendered on both deployments
- [ ] Apply on stage on next release; confirm no manual scale-cycling needed
- [ ] Confirm prod upgrade also clean on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)